### PR TITLE
Added makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PROGRAM_NAME := hello.go
+BIN_NAME := go-hello
+VERSION := 1.0
+ARCH := amd64
+BUILD_DIR := build
+BIN_DIR := /usr/bin
+DEB_FILE := $(BIN_NAME)_$(VERSION)_$(ARCH).deb
+
+deb: $(DEB_FILE)
+	dpkg-deb --build $(BUILD_DIR) $(DEB_FILE)
+
+$(DEB_FILE): $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR)/DEBIAN
+	mkdir -p $(BUILD_DIR)$(BIN_DIR)
+	cp $(BIN_NAME) $(BUILD_DIR)$(BIN_DIR)/$(BIN_NAME)
+	echo "Package: $(BIN_NAME)" > $(BUILD_DIR)/DEBIAN/control
+	echo "Version: $(VERSION)" >> $(BUILD_DIR)/DEBIAN/control
+	echo "Architecture: $(ARCH)" >> $(BUILD_DIR)/DEBIAN/control
+	echo "Maintainer: mettle mettle@mail.com" >> $(BUILD_DIR)/DEBIAN/control
+	echo "Description: A simple go program that prints hello world to stdout" >> $(BUILD_DIR)/DEBIAN/control
+
+$(BUILD_DIR):
+	go build -o $(BIN_NAME) $(PROGRAM_NAME)
+
+clean:
+	rm -rf $(BUILD_DIR) $(DEB_FILE) $(BIN_NAME)


### PR DESCRIPTION
`make deb` creates a .deb package that can be installed with: 
```
# apt install ./<package_name>.deb
```
> make sure `make` and `go` are installed for the build process

`make clean` cleans up all build files including the deb file

pakage version can be specified inside the Makefile which will reflect on the generated deb file

server have been configured to serve the deb over internet. clients can add the following to their `sources.list` file to install this package:
```
# go-hello package
deb [trusted=yes] http://<public_ip_redacted>/debs amd64/

```